### PR TITLE
modify the condition of exit on Weather.Forecast.run/1

### DIFF
--- a/lib/weather/forecast.ex
+++ b/lib/weather/forecast.ex
@@ -14,7 +14,7 @@ defmodule Weather.Forecast do
           else: {:halt, acc}
       end)
 
-    if String.length(description) == 0, do: exit("oh no")
+    if String.length(description) <= String.length("#{name}\n"), do: exit("oh no")
 
     description |> Kernel.<>(i_use_nerves())
   end


### PR DESCRIPTION
'cause description has "#{name}\n".