### PR TITLE
Add default value to some config settings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -41,9 +41,9 @@ config :hello_nerves,
   nhk_favorite_titles: System.get_env("HELLO_NERVES_NHK_FAVORITE_TITLES"),
   twitter_query: System.get_env("HELLO_NERVES_TWITTER_QUERY"),
   twitter_last_created_at:
-    System.get_env("HELLO_NERVES_TWITTER_LAST_CREATED_AT") |> String.to_integer(),
+    System.get_env("HELLO_NERVES_TWITTER_LAST_CREATED_AT", "0") |> String.to_integer(),
   twitter_search_interval:
-    System.get_env("HELLO_NERVES_TWITTER_SEARCH_INTERVAL") |> String.to_integer(),
+    System.get_env("HELLO_NERVES_TWITTER_SEARCH_INTERVAL", "0") |> String.to_integer(),
   slack_incoming_webhook_url: System.get_env("HELLO_NERVES_SLACK_INCOMING_WEBHOOK_URL"),
   slack_channel: System.get_env("HELLO_NERVES_SLACK_CHANNEL"),
   open_weather_api_key: System.get_env("HELLO_NERVES_OPEN_WEATHER_API_KEY"),


### PR DESCRIPTION
`String.to_integer()` explodes when the specified value is not a number.

```elixir
iex> nil |> String.to_integer()
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a binary

    :erlang.binary_to_integer(nil)
```

This error happens when some environment variables are missing.

Alternatively we could raise a friendly error that explains about the missing environment variable.