### PR TITLE
Use EEx for templates

### DIFF
--- a/lib/qiita/events/qiita_delika_202203/markdown_generator.ex
+++ b/lib/qiita/events/qiita_delika_202203/markdown_generator.ex
@@ -1,18 +1,15 @@
 defmodule Qiita.Events.Qiitadelika202203.MarkdownGenerator do
   use Qiita.Events.MarkdownGenerator
 
-  defmodule Data do
-    defstruct item_count: 0, tables: {}
-  end
-
-  alias Qiita.Events.Qiitadelika202203.MarkdownGenerator.Data
   alias Qiita.Events.TableUtils
+
+  @template_path "lib/qiita/events/qiita_delika_202203/template.md"
 
   @impl true
   def generate(items) do
     items
     |> sort_items()
-    |> build_data()
+    |> build_bindings()
     |> build_markdown()
   end
 
@@ -20,95 +17,19 @@ defmodule Qiita.Events.Qiitadelika202203.MarkdownGenerator do
     Enum.sort_by(items, fn %{"likes_count" => likes_count} -> likes_count end, :desc)
   end
 
-  defp build_data(items) do
-    %Data{
+  defp build_bindings(items) do
+    [
       item_count: Enum.count(items),
-      tables: {
-        table(items, :a),
-        table(items, :b),
-        table(items, :c),
-        table(items, :d),
-        table(items, :e)
-      }
-    }
+      table_a: table(items, :a),
+      table_b: table(items, :b),
+      table_c: table(items, :c),
+      table_d: table(items, :d),
+      table_e: table(items, :e)
+    ]
   end
 
-  defp build_markdown(%Data{
-         item_count: item_count,
-         tables: {table_a, table_b, table_c, table_d, table_e}
-       }) do
-    """
-    https://qiita.com/official-events/30be12dd14c0aad2c1c2
-
-    # この記事は
-
-    「[データに関する記事を書こう！](https://qiita.com/official-events/30be12dd14c0aad2c1c2)」
-    キャンペーンの参加記事です。
-    テーマ2『データに関する記事を書こう！』に参加しています。
-
-    [Qiita API v2](https://qiita.com/api/v2/docs)を利用させていただいて、「[データに関する記事を書こう！](https://qiita.com/official-events/30be12dd14c0aad2c1c2)」に参加しているとおもわれる記事を収拾します。
-    あつまった記事群（データ）にあれこれしてみます。
-
-    - LGTM数順に記事を並べます
-    - 投稿者ごとの記事数を集計します
-    - 投稿者ごとのLGTM数を集計します
-    - tagごとの記事数を集計します
-    - tagごとのLGTM数を集計します
-
-    **面白い結果がでること**間違いなしです。
-    だって、キャンペーン自体が面白いのですもの！！！
-
-    「参加ボタン」を押すのをお忘れなく!!!
-    参考: [本ページの「参加する」ボタンをクリックしていること](https://qiita.com/kaizen_nagoya/items/03500a8137e446893c97#%E6%9C%AC%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%AE%E5%8F%82%E5%8A%A0%E3%81%99%E3%82%8B%E3%83%9C%E3%82%BF%E3%83%B3%E3%82%92%E3%82%AF%E3%83%AA%E3%83%83%E3%82%AF%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E3%81%93%E3%81%A8)
-
-    ---
-
-    # 総件数
-    #{item_count}件 :tada::tada::tada:
-
-    # LGTM数 :confetti_ball::military_medal::confetti_ball:
-    #{table_a}
-
-    # 投稿者ごとの記事数とLGTM数
-    #{table_b}
-
-    # 投稿者ごとのLGTM数と記事数
-    #{table_c}
-
-    # タグごとの記事数とLGTM数
-    #{table_d}
-
-    # タグごとのLGTM数と記事数
-    #{table_e}
-
-    ---
-
-    # Wrapping up :lgtm: :qiitan: :lgtm:
-
-    いかがでしょうか。
-    **面白い結果**がでましたよね！！！
-    いやぁ、データって本当にいいもんですね～ :movie_camera:
-
-    般若心経の最初に「観自在菩薩」とあります。
-    データにおいてもまず「観」ることが出発点なのだとおもいます。
-    「観」る、観察する、つまり気づきを出発点として、自在にデータを分析をすることでその終着として、**面白い結果**が得られるのです。
-    みえる形にするにはまず集めることが必要です。
-    [イベントの概要](https://qiita.com/official-events/30be12dd14c0aad2c1c2#%E6%A6%82%E8%A6%81)に記載されている「**データの民主化**」に激しく同意いたします。
-
-    ---
-
-    最後に、この記事を自動更新しているプログラムについて補足しておきます。
-
-    - 自動更新は、[Elixir](https://elixir-lang.org/)というプログラミング言語がありまして、その[Elixir](https://elixir-lang.org/)で作られた[Nerves](https://www.nerves-project.org/)という[ナウでヤングでcoolなすごいIoTフレームワーク](https://www.slideshare.net/takasehideki/elixiriotcoolnerves-236780506)を使ってつくったアプリケーションで行っております
-      - [Nerves](https://www.nerves-project.org/)の始め方につきましては下記の記事が詳しいです
-      - [ElixirでIoT#4.1：Nerves開発環境の準備](https://qiita.com/takasehideki/items/88dda57758051d45fcf9)
-    - [Elixir](https://elixir-lang.org/)には、データを自在に取り扱える[Enum](https://hexdocs.pm/elixir/Enum.html)モジュールがあります
-    - [Elixir](https://elixir-lang.org/)をはじめてみようという方は、[Enum](https://hexdocs.pm/elixir/Enum.html)モジュールの習得からはじめるとよいとおもいます
-    - [WEB+DB PRESS Vol.127](https://gihyo.jp/magazine/wdpress/archive/2022/vol127) :book: の特集２「Elixirによる高速なWeb開発！ 作って学ぶPhoenix」は、[Elixir](https://elixir-lang.org/)でWebアプリケーション開発を楽しめる[Phoenix](https://www.phoenixframework.org/)の基礎がぎっしりと詰まっていて、**オススメ**です
-    - プログラムは、 https://github.com/TORIFUKUKaiou/hello_nerves/blob/master/lib/qiita/events/qiita_delika_202203.ex にあります
-
-    https://github.com/TORIFUKUKaiou/hello_nerves/blob/master/lib/qiita/events/qiita_delika_202203.ex
-    """
+  defp build_markdown(bindings) when is_list(bindings) do
+    EEx.eval_file(@template_path, bindings)
   end
 
   defp table(items, :a) do

--- a/lib/qiita/events/qiita_delika_202203/template.md
+++ b/lib/qiita/events/qiita_delika_202203/template.md
@@ -1,0 +1,70 @@
+https://qiita.com/official-events/30be12dd14c0aad2c1c2
+
+# この記事は
+
+「[データに関する記事を書こう！](https://qiita.com/official-events/30be12dd14c0aad2c1c2)」
+キャンペーンの参加記事です。
+テーマ2『データに関する記事を書こう！』に参加しています。
+
+[Qiita API v2](https://qiita.com/api/v2/docs)を利用させていただいて、「[データに関する記事を書こう！](https://qiita.com/official-events/30be12dd14c0aad2c1c2)」に参加しているとおもわれる記事を収拾します。
+あつまった記事群（データ）にあれこれしてみます。
+
+- LGTM数順に記事を並べます
+- 投稿者ごとの記事数を集計します
+- 投稿者ごとのLGTM数を集計します
+- tagごとの記事数を集計します
+- tagごとのLGTM数を集計します
+
+**面白い結果がでること**間違いなしです。
+だって、キャンペーン自体が面白いのですもの！！！
+
+「参加ボタン」を押すのをお忘れなく!!!
+参考: [本ページの「参加する」ボタンをクリックしていること](https://qiita.com/kaizen_nagoya/items/03500a8137e446893c97#%E6%9C%AC%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%AE%E5%8F%82%E5%8A%A0%E3%81%99%E3%82%8B%E3%83%9C%E3%82%BF%E3%83%B3%E3%82%92%E3%82%AF%E3%83%AA%E3%83%83%E3%82%AF%E3%81%97%E3%81%A6%E3%81%84%E3%82%8B%E3%81%93%E3%81%A8)
+
+---
+
+# 総件数
+<%= item_count %>件 :tada::tada::tada:
+
+# LGTM数 :confetti_ball::military_medal::confetti_ball:
+<%= table_a %>
+
+# 投稿者ごとの記事数とLGTM数
+<%= table_b %>
+
+# 投稿者ごとのLGTM数と記事数
+<%= table_c %>
+
+# タグごとの記事数とLGTM数
+<%= table_d %>
+
+# タグごとのLGTM数と記事数
+<%= table_e %>
+
+---
+
+# Wrapping up :lgtm: :qiitan: :lgtm:
+
+いかがでしょうか。
+**面白い結果**がでましたよね！！！
+いやぁ、データって本当にいいもんですね～ :movie_camera:
+
+般若心経の最初に「観自在菩薩」とあります。
+データにおいてもまず「観」ることが出発点なのだとおもいます。
+「観」る、観察する、つまり気づきを出発点として、自在にデータを分析をすることでその終着として、**面白い結果**が得られるのです。
+みえる形にするにはまず集めることが必要です。
+[イベントの概要](https://qiita.com/official-events/30be12dd14c0aad2c1c2#%E6%A6%82%E8%A6%81)に記載されている「**データの民主化**」に激しく同意いたします。
+
+---
+
+最後に、この記事を自動更新しているプログラムについて補足しておきます。
+
+- 自動更新は、[Elixir](https://elixir-lang.org/)というプログラミング言語がありまして、その[Elixir](https://elixir-lang.org/)で作られた[Nerves](https://www.nerves-project.org/)という[ナウでヤングでcoolなすごいIoTフレームワーク](https://www.slideshare.net/takasehideki/elixiriotcoolnerves-236780506)を使ってつくったアプリケーションで行っております
+  - [Nerves](https://www.nerves-project.org/)の始め方につきましては下記の記事が詳しいです
+  - [ElixirでIoT#4.1：Nerves開発環境の準備](https://qiita.com/takasehideki/items/88dda57758051d45fcf9)
+- [Elixir](https://elixir-lang.org/)には、データを自在に取り扱える[Enum](https://hexdocs.pm/elixir/Enum.html)モジュールがあります
+- [Elixir](https://elixir-lang.org/)をはじめてみようという方は、[Enum](https://hexdocs.pm/elixir/Enum.html)モジュールの習得からはじめるとよいとおもいます
+- [WEB+DB PRESS Vol.127](https://gihyo.jp/magazine/wdpress/archive/2022/vol127) :book: の特集２「Elixirによる高速なWeb開発！ 作って学ぶPhoenix」は、[Elixir](https://elixir-lang.org/)でWebアプリケーション開発を楽しめる[Phoenix](https://www.phoenixframework.org/)の基礎がぎっしりと詰まっていて、**オススメ**です
+- プログラムは、 https://github.com/TORIFUKUKaiou/hello_nerves/blob/master/lib/qiita/events/qiita_delika_202203.ex にあります
+
+https://github.com/TORIFUKUKaiou/hello_nerves/blob/master/lib/qiita/events/qiita_delika_202203.ex

--- a/lib/qiita/events/qiita_wish_new_face_the_best_202204/markdown_generator.ex
+++ b/lib/qiita/events/qiita_wish_new_face_the_best_202204/markdown_generator.ex
@@ -1,18 +1,15 @@
 defmodule Qiita.Events.QiitaWishNewFaceTheBest202204.MarkdownGenerator do
   use Qiita.Events.MarkdownGenerator
 
-  defmodule Data do
-    defstruct item_count: 0, tables: {}
-  end
-
-  alias Qiita.Events.QiitaWishNewFaceTheBest202204.MarkdownGenerator.Data
   alias Qiita.Events.TableUtils
+
+  @template_path "lib/qiita/events/qiita_wish_new_face_the_best_202204/template.md"
 
   @impl true
   def generate(items) do
     items
     |> sort_items()
-    |> build_data()
+    |> build_bindings()
     |> build_markdown()
   end
 
@@ -20,121 +17,19 @@ defmodule Qiita.Events.QiitaWishNewFaceTheBest202204.MarkdownGenerator do
     Enum.sort_by(items, fn %{"likes_count" => likes_count} -> likes_count end, :desc)
   end
 
-  defp build_data(items) do
-    %Data{
+  defp build_bindings(items) do
+    [
       item_count: Enum.count(items),
-      tables: {
-        table(items, :a),
-        table(items, :b),
-        table(items, :c),
-        table(items, :d),
-        table(items, :e)
-      }
-    }
+      table_a: table(items, :a),
+      table_b: table(items, :b),
+      table_c: table(items, :c),
+      table_d: table(items, :d),
+      table_e: table(items, :e)
+    ]
   end
 
-  defp build_markdown(%Data{
-         item_count: item_count,
-         tables: {table_a, table_b, table_c, table_d, table_e}
-       }) do
-    """
-    https://qiita.com/official-events/3f21c92121aa125807b4
-
-    # この記事は
-
-    「[新人プログラマ応援 - みんなで新人を育てよう！](https://qiita.com/official-events/3f21c92121aa125807b4)」
-    キャンペーンの参加記事です。
-    [Qiita API v2](https://qiita.com/api/v2/docs)を利用させていただいて、「[新人プログラマ応援 - みんなで新人を育てよう！](https://qiita.com/official-events/3f21c92121aa125807b4)」に参加しているとおもわれる記事を収拾します。
-    [新人プログラマ応援](https://qiita.com/tags/%e6%96%b0%e4%ba%ba%e3%83%97%e3%83%ad%e3%82%b0%e3%83%a9%e3%83%9e%e5%bf%9c%e6%8f%b4) タグが設定された記事のみを集めています。[^1]
-
-    [^1]: [新人プログラマ応援](https://qiita.com/tags/%e6%96%b0%e4%ba%ba%e3%83%97%e3%83%ad%e3%82%b0%e3%83%a9%e3%83%9e%e5%bf%9c%e6%8f%b4) タグを付けることは必須ではないようですが、このページではタグが付いている記事のみに絞っています。
-
-    あつまった記事群（データ）にあれこれしてみます。
-
-    - LGTM数順に記事を並べます
-    - 投稿者ごとの記事数を集計します
-    - 投稿者ごとのLGTM数を集計します
-    - tagごとの記事数を集計します
-    - tagごとのLGTM数を集計します
-
-    **新人プログラマさんを応援します！**
-
-    「参加ボタン」を押すのをお忘れなく!!!
-
-    ---
-
-    # 総件数
-    #{item_count}件 :tada::tada::tada:
-
-    # LGTM数 :confetti_ball::military_medal::confetti_ball:
-    #{table_a}
-
-    # 投稿者ごとの記事数とLGTM数
-    #{table_b}
-
-    # 投稿者ごとのLGTM数と記事数
-    #{table_c}
-
-    # タグごとの記事数とLGTM数
-    #{table_d}
-
-    # タグごとのLGTM数と記事数
-    #{table_e}
-
-    ---
-
-    # Wrapping up :lgtm: :qiitan: :lgtm:
-
-    <font color="purple">$\\huge{新人プログラマさんを応援します🚀}$</font>
-
-    新人プログラマさん向けの記事と侮るなかれ。（これは私自身、自分自身に対して言っています）
-
-    このページに挙がっている[記事の一覧](https://qiita.com/torifukukaiou/items/18dad64ba99aa5a40f95#lgtm%E6%95%B0-confetti_ballmilitary_medalconfetti_ball)は諸先輩方の汗と涙の結晶です。
-    記事の中には愛と勇気が詰まっています。
-    聞くも涙語るも涙の物語たちです。
-    友情、努力、勝利です。
-    きっと私自身が学びを得られる良い記事にたくさん出会えるとおもっています。
-    **新人プログラマさんを応援する諸先輩方みなさまを応援します！**
-
-    新人プログラマさんのお役にたてれば望外の喜びです。
-
-
-    ---
-
-    最後に、この記事を自動更新しているプログラムについて補足しておきます。
-
-    - 自動更新は、[Elixir](https://elixir-lang.org/)というプログラミング言語がありまして、その[Elixir](https://elixir-lang.org/)で作られた[Nerves](https://www.nerves-project.org/)という[ナウでヤングでcoolなすごいIoTフレームワーク](https://www.slideshare.net/takasehideki/elixiriotcoolnerves-236780506)を使ってつくったアプリケーションで行っております
-      - [Nerves](https://www.nerves-project.org/)の始め方につきましては下記の記事が詳しいです
-      - [ElixirでIoT#4.1：Nerves開発環境の準備](https://qiita.com/takasehideki/items/88dda57758051d45fcf9)
-      - Raspberry Pi 2で動いています。
-    - [Elixir](https://elixir-lang.org/)には、データを自在に取り扱える[Enum](https://hexdocs.pm/elixir/Enum.html)モジュールがあります
-    - [Elixir](https://elixir-lang.org/)をはじめてみようという方は、[Enum](https://hexdocs.pm/elixir/Enum.html)モジュールの習得からはじめるとよいとおもいます
-    - [WEB+DB PRESS Vol.127](https://gihyo.jp/magazine/wdpress/archive/2022/vol127) :book: の特集２「Elixirによる高速なWeb開発！ 作って学ぶPhoenix」は、[Elixir](https://elixir-lang.org/)でWebアプリケーション開発を楽しめる[Phoenix](https://www.phoenixframework.org/)の基礎がぎっしりと詰まっていて、**オススメ**です
-    - プログラムは、 https://github.com/TORIFUKUKaiou/hello_nerves/blob/master/lib/qiita/events/qiita_wish_new_face_the_best_202204.ex にあります
-
-    https://github.com/TORIFUKUKaiou/hello_nerves/blob/master/lib/qiita/events/qiita_wish_new_face_the_best_202204.ex
-
-    ---
-
-    # 追伸
-
-    新人プログラマさん
-    各種イベントや勉強会、コミュニティなどにはぜひ参加してみてください。
-
-    上記で紹介した、[Elixir](https://elixir-lang.org/) 言語に興味がある方へのお知らせです。
-    朗報です。
-    下記のリンク先にあるように、プログラミング言語[Elixir](https://elixir-lang.org/)では、たくさんの勉強会などが開催されています。
-    ぜひ思い切って飛び込んでみてください。
-    [Elixir](https://elixir-lang.org/)のコミュニティはあなた（新人プログラマさんだけに限りません！）の訪れを**熱烈歓迎**します :older_woman::purple_heart:
-
-    [Elixirイベントカレンダー](https://elixir-jp-calendar.fly.dev/)
-
-    https://elixir-jp-calendar.fly.dev/
-
-    ---
-
-    https://qiita.com/official-events/30be12dd14c0aad2c1c2
-    """
+  defp build_markdown(bindings) when is_list(bindings) do
+    EEx.eval_file(@template_path, bindings)
   end
 
   defp table(items, :a) do

--- a/lib/qiita/events/qiita_wish_new_face_the_best_202204/template.md
+++ b/lib/qiita/events/qiita_wish_new_face_the_best_202204/template.md
@@ -1,0 +1,96 @@
+https://qiita.com/official-events/3f21c92121aa125807b4
+
+# この記事は
+
+「[新人プログラマ応援 - みんなで新人を育てよう！](https://qiita.com/official-events/3f21c92121aa125807b4)」
+キャンペーンの参加記事です。
+[Qiita API v2](https://qiita.com/api/v2/docs)を利用させていただいて、「[新人プログラマ応援 - みんなで新人を育てよう！](https://qiita.com/official-events/3f21c92121aa125807b4)」に参加しているとおもわれる記事を収拾します。
+[新人プログラマ応援](https://qiita.com/tags/%e6%96%b0%e4%ba%ba%e3%83%97%e3%83%ad%e3%82%b0%e3%83%a9%e3%83%9e%e5%bf%9c%e6%8f%b4) タグが設定された記事のみを集めています。[^1]
+
+[^1]: [新人プログラマ応援](https://qiita.com/tags/%e6%96%b0%e4%ba%ba%e3%83%97%e3%83%ad%e3%82%b0%e3%83%a9%e3%83%9e%e5%bf%9c%e6%8f%b4) タグを付けることは必須ではないようですが、このページではタグが付いている記事のみに絞っています。
+
+あつまった記事群（データ）にあれこれしてみます。
+
+- LGTM数順に記事を並べます
+- 投稿者ごとの記事数を集計します
+- 投稿者ごとのLGTM数を集計します
+- tagごとの記事数を集計します
+- tagごとのLGTM数を集計します
+
+**新人プログラマさんを応援します！**
+
+「参加ボタン」を押すのをお忘れなく!!!
+
+---
+
+# 総件数
+<%= item_count %>件 :tada::tada::tada:
+
+# LGTM数 :confetti_ball::military_medal::confetti_ball:
+<%= table_a %>
+
+# 投稿者ごとの記事数とLGTM数
+<%= table_b %>
+
+# 投稿者ごとのLGTM数と記事数
+<%= table_c %>
+
+# タグごとの記事数とLGTM数
+<%= table_d %>
+
+# タグごとのLGTM数と記事数
+<%= table_e %>
+
+---
+
+# Wrapping up :lgtm: :qiitan: :lgtm:
+
+<font color="purple">$\\huge{新人プログラマさんを応援します🚀}$</font>
+
+新人プログラマさん向けの記事と侮るなかれ。（これは私自身、自分自身に対して言っています）
+
+このページに挙がっている[記事の一覧](https://qiita.com/torifukukaiou/items/18dad64ba99aa5a40f95#lgtm%E6%95%B0-confetti_ballmilitary_medalconfetti_ball)は諸先輩方の汗と涙の結晶です。
+記事の中には愛と勇気が詰まっています。
+聞くも涙語るも涙の物語たちです。
+友情、努力、勝利です。
+きっと私自身が学びを得られる良い記事にたくさん出会えるとおもっています。
+**新人プログラマさんを応援する諸先輩方みなさまを応援します！**
+
+新人プログラマさんのお役にたてれば望外の喜びです。
+
+
+---
+
+最後に、この記事を自動更新しているプログラムについて補足しておきます。
+
+- 自動更新は、[Elixir](https://elixir-lang.org/)というプログラミング言語がありまして、その[Elixir](https://elixir-lang.org/)で作られた[Nerves](https://www.nerves-project.org/)という[ナウでヤングでcoolなすごいIoTフレームワーク](https://www.slideshare.net/takasehideki/elixiriotcoolnerves-236780506)を使ってつくったアプリケーションで行っております
+  - [Nerves](https://www.nerves-project.org/)の始め方につきましては下記の記事が詳しいです
+  - [ElixirでIoT#4.1：Nerves開発環境の準備](https://qiita.com/takasehideki/items/88dda57758051d45fcf9)
+  - Raspberry Pi 2で動いています。
+- [Elixir](https://elixir-lang.org/)には、データを自在に取り扱える[Enum](https://hexdocs.pm/elixir/Enum.html)モジュールがあります
+- [Elixir](https://elixir-lang.org/)をはじめてみようという方は、[Enum](https://hexdocs.pm/elixir/Enum.html)モジュールの習得からはじめるとよいとおもいます
+- [WEB+DB PRESS Vol.127](https://gihyo.jp/magazine/wdpress/archive/2022/vol127) :book: の特集２「Elixirによる高速なWeb開発！ 作って学ぶPhoenix」は、[Elixir](https://elixir-lang.org/)でWebアプリケーション開発を楽しめる[Phoenix](https://www.phoenixframework.org/)の基礎がぎっしりと詰まっていて、**オススメ**です
+- プログラムは、 https://github.com/TORIFUKUKaiou/hello_nerves/blob/master/lib/qiita/events/qiita_wish_new_face_the_best_202204.ex にあります
+
+https://github.com/TORIFUKUKaiou/hello_nerves/blob/master/lib/qiita/events/qiita_wish_new_face_the_best_202204.ex
+
+---
+
+# 追伸
+
+新人プログラマさん
+各種イベントや勉強会、コミュニティなどにはぜひ参加してみてください。
+
+上記で紹介した、[Elixir](https://elixir-lang.org/) 言語に興味がある方へのお知らせです。
+朗報です。
+下記のリンク先にあるように、プログラミング言語[Elixir](https://elixir-lang.org/)では、たくさんの勉強会などが開催されています。
+ぜひ思い切って飛び込んでみてください。
+[Elixir](https://elixir-lang.org/)のコミュニティはあなた（新人プログラマさんだけに限りません！）の訪れを**熱烈歓迎**します :older_woman::purple_heart:
+
+[Elixirイベントカレンダー](https://elixir-jp-calendar.fly.dev/)
+
+https://elixir-jp-calendar.fly.dev/
+
+---
+
+https://qiita.com/official-events/30be12dd14c0aad2c1c2

--- a/test/qiita/events/qiita_delika_202203_test.exs
+++ b/test/qiita/events/qiita_delika_202203_test.exs
@@ -1,0 +1,25 @@
+defmodule Qiita.Events.Qiitadelika202203Test do
+  use ExUnit.Case
+
+  def qiita_items do
+    [
+      %{
+        "title" => "【毎日自動更新】test",
+        "likes_count" => 65535,
+        "updated_at" => ~U[2022-04-02 18:22:06.038435Z],
+        "created_at" => ~U[2022-04-02 18:22:06.038435Z],
+        "url" => "https://example.com",
+        "user_id" => 255,
+        "tags" => ["elixir"]
+      }
+    ]
+  end
+
+  describe "Qiitadelika202203.MarkdownGenerator" do
+    alias Qiita.Events.Qiitadelika202203.MarkdownGenerator
+
+    test "generate/1 generates markdown with qiita items" do
+      assert qiita_items() |> MarkdownGenerator.generate() =~ "【毎日自動更新】test"
+    end
+  end
+end

--- a/test/qiita/events/qiita_wish_new_face_the_best_202204.exs
+++ b/test/qiita/events/qiita_wish_new_face_the_best_202204.exs
@@ -1,0 +1,25 @@
+defmodule Qiita.Events.QiitaWishNewFaceTheBest202204Test do
+  use ExUnit.Case
+
+  def qiita_items do
+    [
+      %{
+        "title" => "【毎日自動更新】test",
+        "likes_count" => 65535,
+        "updated_at" => ~U[2022-04-02 18:22:06.038435Z],
+        "created_at" => ~U[2022-04-02 18:22:06.038435Z],
+        "url" => "https://example.com",
+        "user_id" => 255,
+        "tags" => ["elixir"]
+      }
+    ]
+  end
+
+  describe "QiitaWishNewFaceTheBest202204.MarkdownGenerator" do
+    alias Qiita.Events.QiitaWishNewFaceTheBest202204.MarkdownGenerator
+
+    test "generate/1 generates markdown with qiita items" do
+      assert qiita_items() |> MarkdownGenerator.generate() =~ "【毎日自動更新】test"
+    end
+  end
+end


### PR DESCRIPTION
### Description

This pull-request introduces [EEx] for our building markdown contents. One advantage of this approach is that we can now treat our template as a real markdown file.

### Notes

- named `build_bindings` after [EEx.eval_file/2]'s argument name
- removed `Data` struct; the contract is clear enough and [EEx.eval_file/2] will raise when bindings are missing

[EEx]: https://hexdocs.pm/eex/EEx.html
[EEx.eval_file/2]: https://hexdocs.pm/eex/EEx.html#eval_file/2