### PR TITLE
Add :eex to :extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule HelloNerves.MixProject do
   def application do
     [
       mod: {HelloNerves.Application, []},
-      extra_applications: [:logger, :runtime_tools, :extwitter]
+      extra_applications: [:logger, :runtime_tools, :extwitter, :eex]
     ]
   end
 


### PR DESCRIPTION
This might fix the issue addressed in https://github.com/TORIFUKUKaiou/hello_nerves/pull/88.

```
** (UndefinedFunctionError) function EEx.eval_file/2 is undefined (module EEx is not available)
```

This comment from [ityonemo](https://elixirforum.com/u/ityonemo) in [this Elixir Forum post](https://elixirforum.com/t/escript-with-eex-or-release-with-cli-arguments/31500/2?u=mnishiguchi) gives us a hint.

> Don’t forget to add EEx to your list of :extra_applications in Mix.exs if it needs to be there at runtime. Though I feel like it’s generally better to make it so all of your EEx code runs at compile time, if that’s possible for what you’re doing.

In our use case, we want to build the template dynamically based on what we get from the Qiita API so (if we choose to use EEx) I think it is fine to include EEx in the release.
