### PR TITLE
Remove unnecessary code from config.exs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,7 +26,7 @@ config :nerves, source_date_epoch: "1597551838"
 
 config :logger, backends: [RingLogger]
 
-if Mix.target() == :host or Mix.target() == :"" do
+if Mix.target() == :host do
   import_config "host.exs"
 else
   import_config "target.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,7 @@ else
 end
 
 config :hello_nerves,
+  env: Mix.env(),
   nhk_api_key: System.get_env("HELLO_NERVES_NHK_API_KEY"),
   nhk_area: System.get_env("HELLO_NERVES_NHK_AREA"),
   nhk_favorite_acts: System.get_env("HELLO_NERVES_NHK_FAVORITE_ACTS"),

--- a/config/config.exs
+++ b/config/config.exs
@@ -33,7 +33,6 @@ else
 end
 
 config :hello_nerves,
-  target: Mix.target(),
   env: Mix.env(),
   nhk_api_key: System.get_env("HELLO_NERVES_NHK_API_KEY"),
   nhk_area: System.get_env("HELLO_NERVES_NHK_AREA"),

--- a/config/config.exs
+++ b/config/config.exs
@@ -33,7 +33,6 @@ else
 end
 
 config :hello_nerves,
-  env: Mix.env(),
   nhk_api_key: System.get_env("HELLO_NERVES_NHK_API_KEY"),
   nhk_area: System.get_env("HELLO_NERVES_NHK_AREA"),
   nhk_favorite_acts: System.get_env("HELLO_NERVES_NHK_FAVORITE_ACTS"),


### PR DESCRIPTION
I notices a few seemingly unnecessary pieces of code in `config.exs`. It is worth discussing them.

#### `... or Mix.target() == :""` 
- This was for a bug that used to exist in Elixir. Frank san fixed it in Elixir a while ago

#### `target: Mix.target()`
- This is defined twice in `config.exs`

#### `env: Mix.env()`
- This is unused in our code base
- José san discourages us to rely on `Mix.env()` in our code in favor of explicit config settings
- There is a discussion here: https://elixirforum.com/t/a-universal-way-to-detect-environment-in-phoenix/39934