### PR TITLE
Revert "Remove duplicated target setting in config.exs"

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,7 @@ else
 end
 
 config :hello_nerves,
+  target: Mix.target(),
   mix_tasks_upload_hotswap_enabled: Mix.env() == :dev,
   nhk_api_key: System.get_env("HELLO_NERVES_NHK_API_KEY"),
   nhk_area: System.get_env("HELLO_NERVES_NHK_AREA"),


### PR DESCRIPTION
This reverts commit 038ba440a6f1058490ce1e277000a63c3807b905.

- https://github.com/TORIFUKUKaiou/hello_nerves/pull/90 のプルリクをマージしてから、mix upload後にWi-Fiネットワークにつながらないということがありました
- この箇所が影響しているのかどうかわかりませんが、 https://github.com/TORIFUKUKaiou/hello_nerves/pull/90 のうち他の変更は無関係にみえたのでで、ここを戻したらつながったので元に戻してみました
- にわかには信じられないので微妙なコミットです