### PR TITLE
Replace Application.get_env/3 with Application.compile_env/3

### DIFF
--- a/lib/azure/text_to_speech.ex
+++ b/lib/azure/text_to_speech.ex
@@ -1,5 +1,5 @@
 defmodule Azure.TextToSpeech do
-  @subscription_key Application.get_env(:hello_nerves, :azure_text_to_speech_subscription_key)
+  @subscription_key Application.compile_env(:hello_nerves, :azure_text_to_speech_subscription_key)
   @locale "ja-JP"
   @gender "Female"
   @voice_type "Neural"

--- a/lib/hello_nerves/blinker.ex
+++ b/lib/hello_nerves/blinker.ex
@@ -8,7 +8,7 @@ defmodule HelloNerves.Blinker do
   alias Circuits.GPIO
   require Logger
 
-  @output_pin Application.get_env(:hello_nerves, :output_pin, 18)
+  @output_pin Application.compile_env(:hello_nerves, :output_pin, 18)
 
   def start_link(state \\ []) do
     GenServer.start_link(__MODULE__, state, name: __MODULE__)

--- a/lib/hello_nerves/led/seven_seg.ex
+++ b/lib/hello_nerves/led/seven_seg.ex
@@ -1,11 +1,11 @@
 defmodule HelloNerves.Led.SevenSeg do
-  @a_led_pin Application.get_env(:hello_nerves, :a_led_pin, 26)
-  @b_led_pin Application.get_env(:hello_nerves, :b_led_pin, 6)
-  @c_led_pin Application.get_env(:hello_nerves, :c_led_pin, 5)
-  @d_led_pin Application.get_env(:hello_nerves, :d_led_pin, 16)
-  @e_led_pin Application.get_env(:hello_nerves, :e_led_pin, 23)
-  @f_led_pin Application.get_env(:hello_nerves, :f_led_pin, 25)
-  @g_led_pin Application.get_env(:hello_nerves, :g_led_pin, 22)
+  @a_led_pin Application.compile_env(:hello_nerves, :a_led_pin, 26)
+  @b_led_pin Application.compile_env(:hello_nerves, :b_led_pin, 6)
+  @c_led_pin Application.compile_env(:hello_nerves, :c_led_pin, 5)
+  @d_led_pin Application.compile_env(:hello_nerves, :d_led_pin, 16)
+  @e_led_pin Application.compile_env(:hello_nerves, :e_led_pin, 23)
+  @f_led_pin Application.compile_env(:hello_nerves, :f_led_pin, 25)
+  @g_led_pin Application.compile_env(:hello_nerves, :g_led_pin, 22)
 
   alias Circuits.GPIO
 

--- a/lib/hello_nerves/util.ex
+++ b/lib/hello_nerves/util.ex
@@ -1,8 +1,8 @@
 defmodule HelloNerves.Util do
   alias Circuits.GPIO
 
-  @input_pin Application.get_env(:hello_nerves, :input_pin, 24)
-  @weather_input_pin Application.get_env(:hello_nerves, :input_pin, 21)
+  @input_pin Application.compile_env(:hello_nerves, :input_pin, 24)
+  @weather_input_pin Application.compile_env(:hello_nerves, :input_pin, 21)
 
   def input_gpio do
     {:ok, input_gpio} = GPIO.open(@input_pin, :input)

--- a/lib/nhk.ex
+++ b/lib/nhk.ex
@@ -1,7 +1,7 @@
 defmodule Nhk do
-  @area Application.get_env(:hello_nerves, :nhk_area)
-  @favorite_acts Application.get_env(:hello_nerves, :nhk_favorite_acts)
-  @favorite_titles Application.get_env(:hello_nerves, :nhk_favorite_titles)
+  @area Application.compile_env(:hello_nerves, :nhk_area)
+  @favorite_acts Application.compile_env(:hello_nerves, :nhk_favorite_acts)
+  @favorite_titles Application.compile_env(:hello_nerves, :nhk_favorite_titles)
 
   def run do
     first = DateTime.utc_now() |> DateTime.add(9 * 60 * 60, :second)

--- a/lib/nhk/api.ex
+++ b/lib/nhk/api.ex
@@ -1,5 +1,5 @@
 defmodule Nhk.Api do
-  @apikey Application.get_env(:hello_nerves, :nhk_api_key)
+  @apikey Application.compile_env(:hello_nerves, :nhk_api_key)
 
   def get(area, service, date) do
     case HTTPoison.get(url(area, service, date)) do

--- a/lib/twitter_search/worker.ex
+++ b/lib/twitter_search/worker.ex
@@ -2,11 +2,11 @@ defmodule TwitterSearch.Worker do
   use GenServer
 
   @one_minute 60 * 1000
-  @interval Application.get_env(:hello_nerves, :twitter_search_interval)
-  @query Application.get_env(:hello_nerves, :twitter_query)
-  @last_created_at Application.get_env(:hello_nerves, :twitter_last_created_at)
-  @incoming_webhook_url Application.get_env(:hello_nerves, :slack_incoming_webhook_url)
-  @channel Application.get_env(:hello_nerves, :slack_channel)
+  @interval Application.compile_env(:hello_nerves, :twitter_search_interval)
+  @query Application.compile_env(:hello_nerves, :twitter_query)
+  @last_created_at Application.compile_env(:hello_nerves, :twitter_last_created_at)
+  @incoming_webhook_url Application.compile_env(:hello_nerves, :slack_incoming_webhook_url)
+  @channel Application.compile_env(:hello_nerves, :slack_channel)
 
   def start_link(state \\ %{}) do
     GenServer.start_link(__MODULE__, state, name: __MODULE__)

--- a/lib/weather/forecast.ex
+++ b/lib/weather/forecast.ex
@@ -1,5 +1,5 @@
 defmodule Weather.Forecast do
-  @api_key Application.get_env(:hello_nerves, :open_weather_api_key)
+  @api_key Application.compile_env(:hello_nerves, :open_weather_api_key)
   @city_list_json "/usr/local/share/city.list.json"
 
   def run(%{"coord" => %{"lat" => lat, "lon" => lon}, "id" => city_id}) do


### PR DESCRIPTION
### Description

According to the [Compile-time environment] documentation, the use of [Application.get_env/3] at compile time is not recommended. The module attributes get fixed at compile time so when the config value is changed, we must recompile the related files.

>  For those reasons, reading the application environment at runtime should be the first choice. However, if you really have to read the application environment during compilation, we recommend you to use compile_env/3 instead: ...

In some locations, [Application.get_env/3]  is used at runtime in functions, which I think is OK.

### Changes

- Replace [Application.get_env/3] with [Application.compile_env/3] where  [Application.get_env/3]  is used at compile time

[Module attributes]: https://elixir-lang.org/getting-started/module-attributes.html 
[Compile-time environment]: https://hexdocs.pm/elixir/Application.html#module-compile-time-environment 
[Application.compile_env/3]: https://hexdocs.pm/elixir/Application.html#compile_env/3
[Application.get_env/3]: https://hexdocs.pm/elixir/Application.html#get_env/3

