### PR TITLE
refactor: rename app from :awesome_nerves to :hello_nerves

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,7 @@ else
   import_config "target.exs"
 end
 
-config :awesome_nerves,
+config :hello_nerves,
   target: Mix.target(),
   mix_tasks_upload_hotswap_enabled: Mix.env() == :dev,
   nhk_api_key: System.get_env("HELLO_NERVES_NHK_API_KEY"),
@@ -37,7 +37,7 @@ config :awesome_nerves,
   azure_text_to_speech_subscription_key:
     System.get_env("HELLO_NERVES_AZURE_TEXT_TO_SPEECH_SUBSCRIPTION_KEY")
 
-config :awesome_nerves, AwesomeNerves.Scheduler,
+config :hello_nerves, AwesomeNerves.Scheduler,
   jobs: [
     {"59 21 * * *",
      {AwesomeNerves, :sound_forecast,

--- a/lib/awesome_nerves.ex
+++ b/lib/awesome_nerves.ex
@@ -22,7 +22,7 @@ defmodule AwesomeNerves do
     content = Weather.Forecast.run(city) |> Azure.TextToSpeech.run!()
 
     {path, play_cmd} =
-      if Application.get_env(:awesome_nerves, :target) != :host,
+      if Application.get_env(:hello_nerves, :target) != :host,
         do: {"/tmp/output.wav", ~c"aplay -q /tmp/output.wav"},
         else: {"output.wav", ~c"afplay output.wav"}
 

--- a/lib/awesome_nerves/blinker.ex
+++ b/lib/awesome_nerves/blinker.ex
@@ -8,7 +8,7 @@ defmodule AwesomeNerves.Blinker do
   alias Circuits.GPIO
   require Logger
 
-  @output_pin Application.compile_env(:awesome_nerves, :output_pin, 18)
+  @output_pin Application.compile_env(:hello_nerves, :output_pin, 18)
 
   def start_link(state \\ []) do
     GenServer.start_link(__MODULE__, state, name: __MODULE__)

--- a/lib/awesome_nerves/led/seven_seg.ex
+++ b/lib/awesome_nerves/led/seven_seg.ex
@@ -1,11 +1,11 @@
 defmodule AwesomeNerves.Led.SevenSeg do
-  @a_led_pin Application.compile_env(:awesome_nerves, :a_led_pin, 26)
-  @b_led_pin Application.compile_env(:awesome_nerves, :b_led_pin, 6)
-  @c_led_pin Application.compile_env(:awesome_nerves, :c_led_pin, 5)
-  @d_led_pin Application.compile_env(:awesome_nerves, :d_led_pin, 16)
-  @e_led_pin Application.compile_env(:awesome_nerves, :e_led_pin, 23)
-  @f_led_pin Application.compile_env(:awesome_nerves, :f_led_pin, 25)
-  @g_led_pin Application.compile_env(:awesome_nerves, :g_led_pin, 22)
+  @a_led_pin Application.compile_env(:hello_nerves, :a_led_pin, 26)
+  @b_led_pin Application.compile_env(:hello_nerves, :b_led_pin, 6)
+  @c_led_pin Application.compile_env(:hello_nerves, :c_led_pin, 5)
+  @d_led_pin Application.compile_env(:hello_nerves, :d_led_pin, 16)
+  @e_led_pin Application.compile_env(:hello_nerves, :e_led_pin, 23)
+  @f_led_pin Application.compile_env(:hello_nerves, :f_led_pin, 25)
+  @g_led_pin Application.compile_env(:hello_nerves, :g_led_pin, 22)
 
   alias Circuits.GPIO
 

--- a/lib/awesome_nerves/scheduler.ex
+++ b/lib/awesome_nerves/scheduler.ex
@@ -1,3 +1,3 @@
 defmodule AwesomeNerves.Scheduler do
-  use Quantum, otp_app: :awesome_nerves
+  use Quantum, otp_app: :hello_nerves
 end

--- a/lib/awesome_nerves/util.ex
+++ b/lib/awesome_nerves/util.ex
@@ -1,8 +1,8 @@
 defmodule AwesomeNerves.Util do
   alias Circuits.GPIO
 
-  @input_pin Application.compile_env(:awesome_nerves, :input_pin, 24)
-  @weather_input_pin Application.compile_env(:awesome_nerves, :input_pin, 21)
+  @input_pin Application.compile_env(:hello_nerves, :input_pin, 24)
+  @weather_input_pin Application.compile_env(:hello_nerves, :input_pin, 21)
 
   def input_gpio do
     {:ok, input_gpio} = GPIO.open(@input_pin, :input)

--- a/lib/azure/text_to_speech.ex
+++ b/lib/azure/text_to_speech.ex
@@ -1,6 +1,6 @@
 defmodule Azure.TextToSpeech do
   @subscription_key Application.compile_env(
-                      :awesome_nerves,
+                      :hello_nerves,
                       :azure_text_to_speech_subscription_key
                     )
   @locale "ja-JP"

--- a/lib/hello_nerves/application.ex
+++ b/lib/hello_nerves/application.ex
@@ -34,7 +34,7 @@ defmodule HelloNerves.Application do
     end
   else
     defp target_children() do
-      if Application.get_env(:awesome_nerves, :mix_tasks_upload_hotswap_enabled) do
+      if Application.get_env(:hello_nerves, :mix_tasks_upload_hotswap_enabled) do
         System.cmd("epmd", ["-daemon"])
         Node.start(:"pi@nerves-rpi2.local")
         Node.set_cookie(Application.get_env(:mix_tasks_upload_hotswap, :cookie))

--- a/lib/nhk.ex
+++ b/lib/nhk.ex
@@ -1,7 +1,7 @@
 defmodule Nhk do
-  @area Application.compile_env(:awesome_nerves, :nhk_area)
-  @favorite_acts Application.compile_env(:awesome_nerves, :nhk_favorite_acts)
-  @favorite_titles Application.compile_env(:awesome_nerves, :nhk_favorite_titles)
+  @area Application.compile_env(:hello_nerves, :nhk_area)
+  @favorite_acts Application.compile_env(:hello_nerves, :nhk_favorite_acts)
+  @favorite_titles Application.compile_env(:hello_nerves, :nhk_favorite_titles)
 
   def run do
     first = DateTime.utc_now() |> DateTime.add(9 * 60 * 60, :second)
@@ -59,7 +59,7 @@ defmodule Nhk do
   end
 
   defp i_use_nerves do
-    if Application.get_env(:awesome_nerves, :target) != :host do
+    if Application.get_env(:hello_nerves, :target) != :host do
       "\n\nI use Nerves. I like it!"
     else
       ""

--- a/lib/nhk/api.ex
+++ b/lib/nhk/api.ex
@@ -1,5 +1,5 @@
 defmodule Nhk.Api do
-  @apikey Application.compile_env(:awesome_nerves, :nhk_api_key)
+  @apikey Application.compile_env(:hello_nerves, :nhk_api_key)
 
   def get(area, service, date) do
     case HTTPoison.get(url(area, service, date)) do

--- a/lib/weather/forecast.ex
+++ b/lib/weather/forecast.ex
@@ -1,5 +1,5 @@
 defmodule Weather.Forecast do
-  @api_key Application.compile_env(:awesome_nerves, :open_weather_api_key)
+  @api_key Application.compile_env(:hello_nerves, :open_weather_api_key)
 
   def run(%{"coord" => %{"lat" => lat, "lon" => lon}}) do
     name = "飯塚"
@@ -24,7 +24,7 @@ defmodule Weather.Forecast do
   end
 
   defp i_use_nerves do
-    if Application.get_env(:awesome_nerves, :target) != :host do
+    if Application.get_env(:hello_nerves, :target) != :host do
       "I use Nerves. I like it!"
     else
       ""


### PR DESCRIPTION
Replaces all instances of the old application name `:awesome_nerves` with the new name `:hello_nerves` across config, modules, and compile_env usage.

This prepares the project for consistent branding, deployment, and maintenance under the new identity.