### PR TITLE
Remove user filtering from Haw repo

### DIFF
--- a/lib/qiita/haw/repo.ex
+++ b/lib/qiita/haw/repo.ex
@@ -1,5 +1,4 @@
 defmodule Qiita.Haw.Repo do
-
   def post_markdown(markdown, tags, title, id) do
     Qiita.Api.patch_item(
       markdown,

--- a/lib/qiita/haw/repo.ex
+++ b/lib/qiita/haw/repo.ex
@@ -1,6 +1,4 @@
 defmodule Qiita.Haw.Repo do
-  @users ~w(sgtakeru tsuruoka91 mnishiguchi torifukukaiou t_kamiya78 haw_ohnuma Erga-mion r-nakashio)
-  @organization_url_name "haw"
 
   def post_markdown(markdown, tags, title, id) do
     Qiita.Api.patch_item(
@@ -15,13 +13,10 @@ defmodule Qiita.Haw.Repo do
   def fetch_items do
     build_query()
     |> Qiita.Api.items()
-    |> Enum.filter(fn item -> Map.get(item, "organization_url_name") == @organization_url_name end)
   end
 
   defp build_query do
-    @users
-    |> Enum.map(&"user:#{&1}")
-    |> Enum.join(" or ")
+    "org:haw"
   end
 
   defp build_tags(tags) do


### PR DESCRIPTION
## Summary
- simplify query building for Qiita Haw repo
- remove organization filter from item fetch

## Testing
- `mix format` *(fails: command not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f5d5c6b48320a6c5124383f9b91b